### PR TITLE
No more warnings and no more showing of plots if students change backend

### DIFF
--- a/tests/integrals/distanceTest.py
+++ b/tests/integrals/distanceTest.py
@@ -7,7 +7,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/integrals/distanceTest.py
+++ b/tests/integrals/distanceTest.py
@@ -6,10 +6,13 @@ import importlib
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/integrals/histogramTest.py
+++ b/tests/integrals/histogramTest.py
@@ -7,10 +7,13 @@ import importlib
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 
@@ -19,6 +22,7 @@ def before():
 		numpy.seterr('raise')
 	except ImportError:
 		pass
+
 
 def after():
 	try:

--- a/tests/integrals/histogramTest.py
+++ b/tests/integrals/histogramTest.py
@@ -8,7 +8,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/integrals/montecarloTest.py
+++ b/tests/integrals/montecarloTest.py
@@ -8,7 +8,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/integrals/montecarloTest.py
+++ b/tests/integrals/montecarloTest.py
@@ -7,18 +7,22 @@ import importlib
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
-	
+
 	try:
 		import numpy
 		numpy.seterr('raise')
 	except ImportError:
 		pass
+
 
 def after():
 	try:

--- a/tests/integrals/riemannTest.py
+++ b/tests/integrals/riemannTest.py
@@ -1,16 +1,18 @@
 import checkpy.tests as t
 import checkpy.lib as lib
 import checkpy.assertlib as assertlib
-import math
 import importlib
 
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/integrals/riemannTest.py
+++ b/tests/integrals/riemannTest.py
@@ -7,7 +7,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/integrals/rootsTest.py
+++ b/tests/integrals/rootsTest.py
@@ -6,10 +6,13 @@ import importlib
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 
@@ -18,7 +21,6 @@ def before():
 		numpy.seterr('raise')
 	except ImportError:
 		pass
-
 
 def after():
 	try:

--- a/tests/integrals/rootsTest.py
+++ b/tests/integrals/rootsTest.py
@@ -7,7 +7,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/monopoly/monopolyTest.py
+++ b/tests/monopoly/monopolyTest.py
@@ -16,7 +16,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/monopoly/monopolyTest.py
+++ b/tests/monopoly/monopolyTest.py
@@ -15,10 +15,13 @@ from notAllowedCode import *
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/monopoly/monopoly_realisticTest.py
+++ b/tests/monopoly/monopoly_realisticTest.py
@@ -16,7 +16,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/monopoly/monopoly_realisticTest.py
+++ b/tests/monopoly/monopoly_realisticTest.py
@@ -15,6 +15,8 @@ from notAllowedCode import *
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
@@ -28,6 +30,7 @@ def before():
 		numpy.seterr('raise')
 	except ImportError:
 		pass
+
 
 def after():
 	import matplotlib.pyplot as plt

--- a/tests/movement/appleTest.py
+++ b/tests/movement/appleTest.py
@@ -15,10 +15,13 @@ from helpers import apply_function, InvalidFunctionApplication, similar, has_fun
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/movement/appleTest.py
+++ b/tests/movement/appleTest.py
@@ -16,7 +16,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/movement/basejumpTest.py
+++ b/tests/movement/basejumpTest.py
@@ -15,10 +15,13 @@ from helpers import apply_function, InvalidFunctionApplication, similar, has_fun
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/movement/basejumpTest.py
+++ b/tests/movement/basejumpTest.py
@@ -16,7 +16,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/movement/fitTest.py
+++ b/tests/movement/fitTest.py
@@ -15,7 +15,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/movement/fitTest.py
+++ b/tests/movement/fitTest.py
@@ -14,10 +14,13 @@ from notAllowedCode import *
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/movement/tunnelTest.py
+++ b/tests/movement/tunnelTest.py
@@ -15,10 +15,13 @@ from helpers import apply_function, InvalidFunctionApplication, similar, has_fun
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/movement/tunnelTest.py
+++ b/tests/movement/tunnelTest.py
@@ -16,7 +16,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/numbers/plotTest.py
+++ b/tests/numbers/plotTest.py
@@ -15,7 +15,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/numbers/plotTest.py
+++ b/tests/numbers/plotTest.py
@@ -14,10 +14,13 @@ from notAllowedCode import *
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/weather/car_rideTest.py
+++ b/tests/weather/car_rideTest.py
@@ -9,10 +9,13 @@ def sandbox():
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 
@@ -21,7 +24,6 @@ def before():
 		numpy.seterr('raise')
 	except ImportError:
 		pass
-
 
 def after():
 	try:

--- a/tests/weather/car_rideTest.py
+++ b/tests/weather/car_rideTest.py
@@ -10,7 +10,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")

--- a/tests/weather/temperatureTest.py
+++ b/tests/weather/temperatureTest.py
@@ -13,10 +13,13 @@ def sandbox():
 def before():
 	try:
 		import matplotlib
+		import warnings
+		warnings.filterwarnings("ignore", module = "plot")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")
 		lib.neutralizeFunction(plt.pause)
+		lib.neutralizeFunction(plt.show)
 	except ImportError:
 		pass
 

--- a/tests/weather/temperatureTest.py
+++ b/tests/weather/temperatureTest.py
@@ -14,7 +14,7 @@ def before():
 	try:
 		import matplotlib
 		import warnings
-		warnings.filterwarnings("ignore", module = "plot")
+		warnings.filterwarnings("ignore")
 		matplotlib.use("Agg")
 		import matplotlib.pyplot as plt
 		plt.switch_backend("Agg")


### PR DESCRIPTION
@simonpauw 

Student in kwestie kreeg in eerste instantie errors bij het plotten en gebruikte zoals aangegeven tkinter om dat te fixen:

import matplotlib
matplotlib.use('tkagg')
import matplotlib.pyplot as plt

Dit leek te werken en plot zag er goed uit, maar bij het draaien van checkpy werd de plot wel ook getoond, wat blocking was voor de check, en dus een timeout gaf. Als hij tijdig het figuur sloot, werd de test wel gehaald.

.show() geneutraliseerd zodat dit niet meer kan. 

Direct ook de irritante no-gui warning gefilterd.